### PR TITLE
SBT build improvements

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -41,7 +41,7 @@ object GTEngineBuild extends Build {
 
   object BuildSettings {
 
-          val buildOrganization = "kjetland"
+          val buildOrganization = "com.kjetland"
           val buildVersion      = "0.2.1"
           val buildScalaVersion = "2.9.1"
           val buildSbtVersion   = "0.11.2"


### PR DESCRIPTION
Removed Scala version suffix from artifactName. This artifact does not depend on Scala.

Additionally "com.novocode:junit-interface:0.7" test dependency replaced by "junit:junit:4.8.2" - "junit-interface" is not needed.
