### PR TITLE
Unit tests fail on Windows

### DIFF
--- a/src/test/java/play/template2/ExtendsTest.java
+++ b/src/test/java/play/template2/ExtendsTest.java
@@ -30,12 +30,12 @@ public class ExtendsTest {
 
         GTJavaBase t = tr.getTemplateInstance(new GTTemplateLocation("templateUsingExtendsAndTag.txt"));
         t.renderTemplate(args);
-        assertThat( t.getAsString() ).isEqualTo("maintemplateUsingExtends2\n[from tag: x]");
+        assertThat( t.getAsString() ).isEqualTo("maintemplateUsingExtends2" + System.getProperty("line.separator") + "[from tag: x]");
 
         // test nested extends
         t = tr.getTemplateInstance(new GTTemplateLocation("templateUsingExtendsExtendsAndTag.txt"));
         t.renderTemplate(args);
-        assertThat( t.getAsString() ).isEqualTo("maintemplateUsingExtendsxtemplateUsingExtends3\n[from tag: x]");
+        assertThat( t.getAsString() ).isEqualTo("maintemplateUsingExtendsxtemplateUsingExtends3" + System.getProperty("line.separator") + "[from tag: x]");
 
         assertThat( sr.renderSrc("#{tagUsingExtends/}template", args) ).isEqualTo("maintag1template");
         assertThat( sr.renderSrc("#{tagUsingTagUsingExtends/}template", args) ).isEqualTo("maintag1tagxtemplate");

--- a/src/test/java/play/template2/OutOveridingTest.java
+++ b/src/test/java/play/template2/OutOveridingTest.java
@@ -17,7 +17,7 @@ public class OutOveridingTest {
         args.put("myData", "xxx");
 
         assertThat( sr.renderSrc("a%{ print 'b' }%c", args) ).isEqualTo("abc");
-        assertThat( sr.renderSrc("a%{ println('b') }%c", args) ).isEqualTo("ab\nc");
+        assertThat( sr.renderSrc("a%{ println('b') }%c", args) ).isEqualTo("ab" + System.getProperty("line.separator") + "c");
         assertThat( sr.renderSrc("a%{ printf('%d',1) }%c", args) ).isEqualTo("a1c");
 
 

--- a/src/test/java/play/template2/SpecialTests.java
+++ b/src/test/java/play/template2/SpecialTests.java
@@ -21,9 +21,9 @@ public class SpecialTests {
 
         Map<String, Object> args = new HashMap<String, Object>();
 
-        assertThat(sr.renderSrc("A#{printBodyInVerbatim}BC#{/printBodyInVerbatim}C", args)).isEqualTo("A\n[from tag. body: BC]\nC");
-        assertThat(sr.renderSrc("#{include 'simpleTemplate.txt'/}-A#{printBodyInVerbatim}BC#{/printBodyInVerbatim}C", args)).isEqualTo("[from simpleTemplate]-A\n[from tag. body: BC]\nC");
-        assertThat(sr.renderSrc("A#{printBodyInVerbatim}BC\n#{include 'simpleTemplate.txt'/}#{/printBodyInVerbatim}C", args)).isEqualTo("A\n[from tag. body: BC\n[from simpleTemplate]]\nC");
+        assertThat(sr.renderSrc("A#{printBodyInVerbatim}BC#{/printBodyInVerbatim}C", args)).isEqualTo("A" + System.getProperty("line.separator") + "[from tag. body: BC]" + System.getProperty("line.separator") + "C");
+        assertThat(sr.renderSrc("#{include 'simpleTemplate.txt'/}-A#{printBodyInVerbatim}BC#{/printBodyInVerbatim}C", args)).isEqualTo("[from simpleTemplate]-A" + System.getProperty("line.separator") + "[from tag. body: BC]" + System.getProperty("line.separator") + "C");
+        assertThat(sr.renderSrc("A#{printBodyInVerbatim}BC\n#{include 'simpleTemplate.txt'/}#{/printBodyInVerbatim}C", args)).isEqualTo("A" + System.getProperty("line.separator") + "[from tag. body: BC\n[from simpleTemplate]]" + System.getProperty("line.separator") + "C");
 
     }
     


### PR DESCRIPTION
Unit tests failing on Windows fixed. "\n" replaced by System.getProperty("line.separator"). You can polish them (get system property and assign it to a variable once and use this variable).
