### PR TITLE
compatibility fix with Play 1.x #{extends}

### DIFF
--- a/src/main/java/play/template2/GTJavaBase.java
+++ b/src/main/java/play/template2/GTJavaBase.java
@@ -147,7 +147,7 @@ public abstract class GTJavaBase extends GTRenderingResult {
                     extendedTemplate.extendingTemplate = this;
     
                     // ok, render it with original args..
-                    extendedTemplate.internalRenderTemplate(this.orgArgs, false, null );
+                    extendedTemplate.internalRenderTemplate(bindingsMap, false, null );
                 } else {
                     // Extends have been specified somewhere when rendering this template/tag.
                     // Must pass the extends-info up the chain


### PR DESCRIPTION
In real Play 1.x templates, you can define a variable in template and then access it from the #{extend}-ed template.

This pull request replicates this behaviour for compatibility.

**example.html**
```
#{extends 'main.html'}
%{title = 'Hello'}%
```

**main.html**
```
<title>${title ?: 'Default title'}</title>
#{doLayout/}
```
